### PR TITLE
Add data source URL to `*Config.json` files

### DIFF
--- a/Dummy_disease_test/Config.json
+++ b/Dummy_disease_test/Config.json
@@ -1,5 +1,9 @@
 {
     "version": 2,
+    "data": {
+        "source": "https://github.com/imperialCHEPI/healthgps-data/releases/download/20240624/data_20240624.zip",
+        "checksum": "b68abc8d40b937d377aa7357bff66a1f4f5196da5b867f7ca88d02b37d2ebb5c"
+    },
     "inputs": {
         "dataset": {
             "name": "India.DataFile.csv",

--- a/HLM_France/model/France.Config.json
+++ b/HLM_France/model/France.Config.json
@@ -1,5 +1,9 @@
 {
     "version": 2,
+    "data": {
+        "source": "https://github.com/imperialCHEPI/healthgps-data/releases/download/20240624/data_20240624.zip",
+        "checksum": "b68abc8d40b937d377aa7357bff66a1f4f5196da5b867f7ca88d02b37d2ebb5c"
+    },
     "inputs": {
         "dataset": {
             "name": "France.DataFile.csv",

--- a/HLM_India/India.Config.json
+++ b/HLM_India/India.Config.json
@@ -1,5 +1,9 @@
 {
     "version": 2,
+    "data": {
+        "source": "https://github.com/imperialCHEPI/healthgps-data/releases/download/20240624/data_20240624.zip",
+        "checksum": "b68abc8d40b937d377aa7357bff66a1f4f5196da5b867f7ca88d02b37d2ebb5c"
+    },
     "inputs": {
         "dataset": {
             "name": "India.DataFile.csv",

--- a/KevinHall_India/model/Config.json
+++ b/KevinHall_India/model/Config.json
@@ -1,5 +1,9 @@
 {
     "version": 2,
+    "data": {
+        "source": "https://github.com/imperialCHEPI/healthgps-data/releases/download/20240624/data_20240624.zip",
+        "checksum": "b68abc8d40b937d377aa7357bff66a1f4f5196da5b867f7ca88d02b37d2ebb5c"
+    },
     "inputs": {
         "dataset": {
             "name": "India.DataFile.csv",


### PR DESCRIPTION
While the latest version of Health-GPS will still work if the user instead passes a data source via a command-line argument, the new, recommended way is to set the data source in the config file.

Closes #9.

@TinyMarsh @SaranjeetKaur I've tagged you guys as reviewers as @jamesturner246 is away.

@jzhu20 I wanted to make you aware of these changes so I've tagged you as a reviewer too.

Please anyone ask questions if you have any!