### PR TITLE
Change all values of `encoding` from UTF8 to ASCII

### DIFF
--- a/Dummy_disease_test/Config.json
+++ b/Dummy_disease_test/Config.json
@@ -67,7 +67,7 @@
         "baseline_adjustments": {
             "format": "csv",
             "delimiter": ",",
-            "encoding": "UTF8",
+            "encoding": "ASCII",
             "file_names": {
                 "factorsmean_male": "FactorsMean.Male.csv",
                 "factorsmean_female": "FactorsMean.Female.csv"

--- a/Dummy_disease_test/data/index.json
+++ b/Dummy_disease_test/data/index.json
@@ -3,7 +3,7 @@
     "country": {
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "description": "ISO 3166-1 country codes.",
         "source": "International Organization for Standardization",
         "url": "https://www.iso.org/iso-3166-country-codes.html",
@@ -14,7 +14,7 @@
     "demographic": {
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "description": "United Nations (UN) population estimates and projections.",
         "source": "UN Database - World Population Prospects 2019",
         "url": "https://population.un.org/wpp/",
@@ -42,7 +42,7 @@
     "diseases": {
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "description": "Diseases indicators, measures and relative risk factors.",
         "source": "The Institute for Health Metrics and Evaluation - IHME",
         "url": "http://www.healthdata.org/",
@@ -105,7 +105,7 @@
     "analysis": {
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "description": "Observed burden of disease measures and disability weigths.",
         "source": "The Institute for Health Metrics and Evaluation - IHME",
         "url": "http://www.healthdata.org/",

--- a/HLM_France/model/France.Config.json
+++ b/HLM_France/model/France.Config.json
@@ -100,7 +100,7 @@
         "baseline_adjustments": {
             "format": "csv",
             "delimiter": ",",
-            "encoding": "UTF8",
+            "encoding": "ASCII",
             "file_names": {
                 "factorsmean_male": "France.FactorsMean.Male.csv",
                 "factorsmean_female": "France.FactorsMean.Female.csv"

--- a/HLM_India/India.Config.json
+++ b/HLM_India/India.Config.json
@@ -100,7 +100,7 @@
         "baseline_adjustments": {
             "format": "csv",
             "delimiter": ",",
-            "encoding": "UTF8",
+            "encoding": "ASCII",
             "file_names": {
                 "factorsmean_male": "India.FactorsMean.Male.csv",
                 "factorsmean_female": "India.FactorsMean.Female.csv"

--- a/KevinHall_India/model/Config.json
+++ b/KevinHall_India/model/Config.json
@@ -132,7 +132,7 @@
         "baseline_adjustments": {
             "format": "csv",
             "delimiter": ",",
-            "encoding": "UTF8",
+            "encoding": "ASCII",
             "file_names": {
                 "factorsmean_male": "FactorsMean.Male.csv",
                 "factorsmean_female": "FactorsMean.Female.csv"

--- a/KevinHall_India/model/KevinHall.json
+++ b/KevinHall_India/model/KevinHall.json
@@ -57,7 +57,7 @@
             "name": "weight_quantiles_NCDRisk_female.csv",
             "format": "csv",
             "delimiter": ",",
-            "encoding": "UTF8",
+            "encoding": "ASCII",
             "columns": {
                 "quantile": "double"
             }
@@ -66,7 +66,7 @@
             "name": "weight_quantiles_NCDRisk_male.csv",
             "format": "csv",
             "delimiter": ",",
-            "encoding": "UTF8",
+            "encoding": "ASCII",
             "columns": {
                 "quantile": "double"
             }
@@ -76,7 +76,7 @@
         "name": "energy_physicalactivity_quantiles.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "quantile": "double"
         }

--- a/KevinHall_India/model/scenario_1/StaticLinear.json
+++ b/KevinHall_India/model/scenario_1/StaticLinear.json
@@ -162,7 +162,7 @@
         "name": "residual_risk_factor_correlation.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",
@@ -174,7 +174,7 @@
         "name": "residual_policy_covariance.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",

--- a/KevinHall_India/model/scenario_1_reformulation/StaticLinear.json
+++ b/KevinHall_India/model/scenario_1_reformulation/StaticLinear.json
@@ -162,7 +162,7 @@
         "name": "residual_risk_factor_correlation.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",
@@ -174,7 +174,7 @@
         "name": "residual_policy_covariance.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",

--- a/KevinHall_India/model/scenario_1_subsidy/StaticLinear.json
+++ b/KevinHall_India/model/scenario_1_subsidy/StaticLinear.json
@@ -162,7 +162,7 @@
         "name": "residual_risk_factor_correlation.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",
@@ -174,7 +174,7 @@
         "name": "residual_policy_covariance.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",

--- a/KevinHall_India/model/scenario_2/StaticLinear.json
+++ b/KevinHall_India/model/scenario_2/StaticLinear.json
@@ -162,7 +162,7 @@
         "name": "residual_risk_factor_correlation.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",
@@ -174,7 +174,7 @@
         "name": "residual_policy_covariance.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",

--- a/KevinHall_India/model/scenario_2_reformulation/StaticLinear.json
+++ b/KevinHall_India/model/scenario_2_reformulation/StaticLinear.json
@@ -162,7 +162,7 @@
         "name": "residual_risk_factor_correlation.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",
@@ -174,7 +174,7 @@
         "name": "residual_policy_covariance.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",

--- a/KevinHall_India/model/scenario_2_subsidy/StaticLinear.json
+++ b/KevinHall_India/model/scenario_2_subsidy/StaticLinear.json
@@ -162,7 +162,7 @@
         "name": "residual_risk_factor_correlation.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",
@@ -174,7 +174,7 @@
         "name": "residual_policy_covariance.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",

--- a/KevinHall_India/model/scenario_3/StaticLinear.json
+++ b/KevinHall_India/model/scenario_3/StaticLinear.json
@@ -162,7 +162,7 @@
         "name": "residual_risk_factor_correlation.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",
@@ -174,7 +174,7 @@
         "name": "residual_policy_covariance.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",

--- a/KevinHall_India/model/scenario_3_reformulation/StaticLinear.json
+++ b/KevinHall_India/model/scenario_3_reformulation/StaticLinear.json
@@ -162,7 +162,7 @@
         "name": "residual_risk_factor_correlation.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",
@@ -174,7 +174,7 @@
         "name": "residual_policy_covariance.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",

--- a/KevinHall_India/model/scenario_3_subsidy/StaticLinear.json
+++ b/KevinHall_India/model/scenario_3_subsidy/StaticLinear.json
@@ -162,7 +162,7 @@
         "name": "residual_risk_factor_correlation.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",
@@ -174,7 +174,7 @@
         "name": "residual_policy_covariance.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",

--- a/KevinHall_India/model/scenario_4/StaticLinear.json
+++ b/KevinHall_India/model/scenario_4/StaticLinear.json
@@ -162,7 +162,7 @@
         "name": "residual_risk_factor_correlation.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",
@@ -174,7 +174,7 @@
         "name": "residual_policy_covariance.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",

--- a/KevinHall_India/model/scenario_4_reformulation/StaticLinear.json
+++ b/KevinHall_India/model/scenario_4_reformulation/StaticLinear.json
@@ -162,7 +162,7 @@
         "name": "residual_risk_factor_correlation.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",
@@ -174,7 +174,7 @@
         "name": "residual_policy_covariance.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",

--- a/KevinHall_India/model/scenario_4_subsidy/StaticLinear.json
+++ b/KevinHall_India/model/scenario_4_subsidy/StaticLinear.json
@@ -162,7 +162,7 @@
         "name": "residual_risk_factor_correlation.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",
@@ -174,7 +174,7 @@
         "name": "residual_policy_covariance.csv",
         "format": "csv",
         "delimiter": ",",
-        "encoding": "UTF8",
+        "encoding": "ASCII",
         "columns": {
             "FoodCarbohydrate": "double",
             "FoodFat": "double",


### PR DESCRIPTION
After checking, it seems that they're all actually plain ASCII anyway. This field isn't actually used for anything in Health-GPS, but let's simplify the config files to avoid confusion. I'm not sure Health-GPS would actually work with unicode text on all platforms anyway.