### PR TITLE
Add `$schema` property to config files

### DIFF
--- a/Dummy_disease_test/Config.json
+++ b/Dummy_disease_test/Config.json
@@ -1,6 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config.json",
-    "version": 2,
     "data": {
         "source": "https://github.com/imperialCHEPI/healthgps-data/releases/download/20240624/data_20240624.zip",
         "checksum": "b68abc8d40b937d377aa7357bff66a1f4f5196da5b867f7ca88d02b37d2ebb5c"

--- a/Dummy_disease_test/Config.json
+++ b/Dummy_disease_test/Config.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config.json",
     "version": 2,
     "data": {
         "source": "https://github.com/imperialCHEPI/healthgps-data/releases/download/20240624/data_20240624.zip",

--- a/Dummy_disease_test/Config.json
+++ b/Dummy_disease_test/Config.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config.json",
+    "version": 2,
     "data": {
         "source": "https://github.com/imperialCHEPI/healthgps-data/releases/download/20240624/data_20240624.zip",
         "checksum": "b68abc8d40b937d377aa7357bff66a1f4f5196da5b867f7ca88d02b37d2ebb5c"

--- a/Dummy_disease_test/data/index.json
+++ b/Dummy_disease_test/data/index.json
@@ -1,5 +1,4 @@
 {
-    "version": 2,
     "country": {
         "format": "csv",
         "delimiter": ",",

--- a/Dummy_disease_test/data/index.json
+++ b/Dummy_disease_test/data/index.json
@@ -1,4 +1,5 @@
 {
+    "version": 2,
     "country": {
         "format": "csv",
         "delimiter": ",",

--- a/HLM_France/model/France.Config.json
+++ b/HLM_France/model/France.Config.json
@@ -1,6 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config.json",
-    "version": 2,
     "data": {
         "source": "https://github.com/imperialCHEPI/healthgps-data/releases/download/20240624/data_20240624.zip",
         "checksum": "b68abc8d40b937d377aa7357bff66a1f4f5196da5b867f7ca88d02b37d2ebb5c"

--- a/HLM_France/model/France.Config.json
+++ b/HLM_France/model/France.Config.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config.json",
     "version": 2,
     "data": {
         "source": "https://github.com/imperialCHEPI/healthgps-data/releases/download/20240624/data_20240624.zip",

--- a/HLM_France/model/France.Config.json
+++ b/HLM_France/model/France.Config.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config.json",
+    "version": 2,
     "data": {
         "source": "https://github.com/imperialCHEPI/healthgps-data/releases/download/20240624/data_20240624.zip",
         "checksum": "b68abc8d40b937d377aa7357bff66a1f4f5196da5b867f7ca88d02b37d2ebb5c"

--- a/HLM_India/India.Config.json
+++ b/HLM_India/India.Config.json
@@ -1,6 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config.json",
-    "version": 2,
     "data": {
         "source": "https://github.com/imperialCHEPI/healthgps-data/releases/download/20240624/data_20240624.zip",
         "checksum": "b68abc8d40b937d377aa7357bff66a1f4f5196da5b867f7ca88d02b37d2ebb5c"

--- a/HLM_India/India.Config.json
+++ b/HLM_India/India.Config.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config.json",
     "version": 2,
     "data": {
         "source": "https://github.com/imperialCHEPI/healthgps-data/releases/download/20240624/data_20240624.zip",

--- a/HLM_India/India.Config.json
+++ b/HLM_India/India.Config.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config.json",
+    "version": 2,
     "data": {
         "source": "https://github.com/imperialCHEPI/healthgps-data/releases/download/20240624/data_20240624.zip",
         "checksum": "b68abc8d40b937d377aa7357bff66a1f4f5196da5b867f7ca88d02b37d2ebb5c"

--- a/KevinHall_India/model/Config.json
+++ b/KevinHall_India/model/Config.json
@@ -1,6 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config.json",
-    "version": 2,
     "data": {
         "source": "https://github.com/imperialCHEPI/healthgps-data/releases/download/20240624/data_20240624.zip",
         "checksum": "b68abc8d40b937d377aa7357bff66a1f4f5196da5b867f7ca88d02b37d2ebb5c"

--- a/KevinHall_India/model/Config.json
+++ b/KevinHall_India/model/Config.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config.json",
     "version": 2,
     "data": {
         "source": "https://github.com/imperialCHEPI/healthgps-data/releases/download/20240624/data_20240624.zip",

--- a/KevinHall_India/model/Config.json
+++ b/KevinHall_India/model/Config.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/config.json",
+    "version": 2,
     "data": {
         "source": "https://github.com/imperialCHEPI/healthgps-data/releases/download/20240624/data_20240624.zip",
         "checksum": "b68abc8d40b937d377aa7357bff66a1f4f5196da5b867f7ca88d02b37d2ebb5c"


### PR DESCRIPTION
In preparation for https://github.com/imperialCHEPI/healthgps/issues/449, I've added a `$schema` property to each of the config files. Currently the URL doesn't exist, but it will once I've fixed that issue in the main repo (which I've nearly finished). I've dropped the `version` property, as we no longer need it.

I leave it up to you whether you want to merge before or after https://github.com/imperialCHEPI/healthgps/issues/449 is fixed.